### PR TITLE
server: do not delete sticky threads and also prevent #steal on them

### DIFF
--- a/db/images.go
+++ b/db/images.go
@@ -205,10 +205,12 @@ func TransferImage(fromPost, toPost, thread uint64) (
 				`select p.imageName, p.spoiler, i.*
 				from posts p
 				join images i on i.sha1 = p.sha1
+				join threads t on t.id = p.op
 				where
 					p.id = $1
 					and p.op = $2
 					and p.id != p.op
+					and t.sticky = false
 				for update of p`,
 				fromPost,
 				thread,

--- a/db/upkeep.go
+++ b/db/upkeep.go
@@ -305,7 +305,7 @@ func deleteOldThreads() (err error) {
 		var q *sql.Stmt
 		if len(toDel) != 0 {
 			// Deleted any matched threads
-			q, err = tx.Prepare(`delete from threads where id = $1`)
+			q, err = tx.Prepare(`delete from threads where id = $1 and sticky = false`)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Keep meguTV threads alive indefinitely and also prevents #steal vandalism by shadow bins.